### PR TITLE
Fix oauth_provider and oauth_provider_id being set to null

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -22,7 +22,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password', 'avatar', 'oauth_provider', 'oauth_provider_id'
+        'name', 'email', 'password', 'avatar', 'oauth_provider', 'oauth_provider_id',
     ];
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -22,7 +22,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password', 'avatar',
+        'name', 'email', 'password', 'avatar', 'oauth_provider', 'oauth_provider_id'
     ];
 
     /**


### PR DESCRIPTION
Current User model sets oauth_provider and provider_id to null, rather than expected values; this situation prevents repeat log-in using any oauth method (creates a user with no password and no oauth_provider). This patch resolves.